### PR TITLE
Fix `project_identificator` name

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ export interface IAntilopayBalance {
 }
 
 export interface IAntilopayProjectBalanceResponse extends IAntilopayError {
-  project_indentificator: string;
+  project_identificator: string;
   rub: IAntilopayBalance;
   usd?: IAntilopayBalance;
 }


### PR DESCRIPTION
There's error in `project_identificator` name